### PR TITLE
prevent browser from showing default error message

### DIFF
--- a/jquery.f5.js
+++ b/jquery.f5.js
@@ -213,7 +213,8 @@
 		// Aiming to 'validity' object
 		if (!isNative.hostMethod.validity || opts.error.force) {
 			$$.get(0).control.error = opts.error.create.apply($$);
-			$$.bind('invalid', function() {
+			$$.bind('invalid', function(event) {
+				event.preventDefault();
 				$(this.control.error).text(this.validationMessage);
 			})
 			if ($.browser.msie) {


### PR DESCRIPTION
If a form is submitted with the submit button and there are invalid fields in the form, the browser will display his own error messages. preventDefault on the invalid event will prevent this.
